### PR TITLE
Remove step2 files

### DIFF
--- a/scripts/saige/saige.v35.8.8.Makefile
+++ b/scripts/saige/saige.v35.8.8.Makefile
@@ -1,9 +1,9 @@
 # This make file will run SAIGE pipeline
 
-# This script uses the reference fai index file (REFFILEINDEX) to 
+# This script uses the reference fai index file (REFFILEINDEX) to
 #   create chcuks of size BINSIZE for STEP 2
 # Use THREADS= to set the number of threads to use for STEP 1
-# Use "make -j" to specify the number of parallel jobs for STEP 2 
+# Use "make -j" to specify the number of parallel jobs for STEP 2
 
 # Make variables can be replaced on the command line. For example
 #  make -f saige.Makefile -j20 THREADS=20 RESPONSE=BMI
@@ -20,12 +20,12 @@ REFFILE = /Users/snehalpatil/Documents/GithubProjects/ForkEncore/encore/anno/hs3
 REFFILEINDEX = $(addsuffix .fai, $(REFFILE))
 PHENOFILE = pheno.txt
 PHENOFILEIDCOL = IND_ID
-RESPONSE = "" 
+RESPONSE = ""
 RESPONSETYPE = quantitative
 INVNORM = FALSE
 COVAR = ""
 BINSIZE = 1500000
-THREADS = 8 
+THREADS = 8
 STEP1OPT = --memoryChunk=2
 STEP2OPT = --minMAF=0.001 --IsOutputAFinCaseCtrl=FALSE
 
@@ -79,7 +79,7 @@ $(OUTDIR)step2.bin.%.txt: $(OUTDIR)step1.rda
 STEP2FILES = $(foreach bin,$(BINS),$(OUTDIR)step2.bin.$(bin).txt)
 STEP2LOGS = $(foreach bin,$(STEP2FILES),$(bin).log)
 $(OUTDIR)$(OUTNAME): $(STEP2FILES)
-	awk 'FNR!=1 || NR==1' $^ | tr " " "\t" | bgzip -c > $@ 
+	awk 'FNR!=1 || NR==1' $^ | tr " " "\t" | bgzip -c > $@
 
 $(OUTDIR)$(OUTNAME).tbi: $(OUTDIR)$(OUTNAME)
 	tabix -s1 -b2 -e2 -S1 $^

--- a/scripts/saige/saige.v35.8.8.Makefile
+++ b/scripts/saige/saige.v35.8.8.Makefile
@@ -85,8 +85,11 @@ $(OUTDIR)$(OUTNAME).tbi: $(OUTDIR)$(OUTNAME)
 	tabix -s1 -b2 -e2 -S1 $^
 
 $(OUTDIR)$(LOGNAME).gz: $(OUTDIR)$(OUTNAME).tbi
-	cat $(OUTDIR)$(LOGNAME) $(STEP2LOGS) | gzip -c > $@  && rm $(STEP2LOGS) && rm $(OUTDIR)$(LOGNAME)
+	cat $(OUTDIR)$(LOGNAME) $(STEP2LOGS) | gzip -c > $@
+
+.PHONY: clean
 
 clean:
-        rm -f $(OUTDIR)$(OUTNAME)
-        rm -f $(OUTDIR)$(LOGNAME)
+	rm -f $(STEP2FILES)
+	rm -f $(STEP2LOGS)
+	rm -f $(OUTDIR)$(LOGNAME)


### PR DESCRIPTION
Finish changing Makefile so that all of the commands to remove step2 files and other intermediate files are in the clean Makefile target. The resolves the error we observed when the argument list was too long.