### PR TITLE
Increase backup retention to 150 days

### DIFF
--- a/scripts/db_backup.sh
+++ b/scripts/db_backup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-REACH=31
+REACH=180
 DATE=/bin/date
 DAY=$($DATE +%d)
 MONTH=$($DATE +%m)
@@ -22,12 +22,12 @@ mysqldump --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} \
 LOOP=0
 while [ $LOOP -lt $REACH ]
 do
-    let OFFSET=$LOOP+14
+    let OFFSET=$LOOP+150
     PREV_DATE=$($DATE --date="${YESTERDAY} -${OFFSET}days" +%Y.%m.%d)
     FILE=${BACKUP_LOCATION}/mariadb-backup.${PREV_DATE}.sql
 
     if [ -f "$FILE" ]; then
-        echo "Deleting old daily backup (keep rolling 14 days): ${FILE}"
+        echo "Deleting old daily backup (keep rolling 150 days): ${FILE}"
         rm ${FILE}
         if [ "$?" != "0" ]
         then


### PR DESCRIPTION
I suggest increasing the number of days backup we retain from 14 days to 150 days. This would allow us to recover older backups in case we introduce an error, but do not notice it until later. Each day's backup is about 30 KB, so the files are relatively small and at most, the backups would probably be less than 5 MB of space on the turbo share.