### PR TITLE
Use R with OpenBLAS

### DIFF
--- a/scripts/saige/saige.v35.8.8.Makefile
+++ b/scripts/saige/saige.v35.8.8.Makefile
@@ -30,7 +30,7 @@ STEP1OPT = --memoryChunk=2
 STEP2OPT = --minMAF=0.001 --IsOutputAFinCaseCtrl=FALSE
 
 #RLIBPATH = /net/encore1/saige/lib-v35.8.8
-RSCRIPT = R_LIBS=/sw/ph/centos7/R-modules/:/sw/ph/centos7/saige-py2.7/SAIGE /sw/arcts/centos7/stacks/gcc/8.2.0/R/3.6.1/bin/Rscript
+RSCRIPT = R_LIBS=/sw/ph/centos7/R-modules/:/sw/ph/centos7/saige-py2.7/SAIGE /sw/arcts/centos7/stacks/gcc/8.2.0/Ropenblas/3.6.1/bin/Rscript
 STEP1SCRIPT = $(APPDIR)step1_fitNULLGLMM_v35.R
 STEP2SCRIPT = $(APPDIR)step2_SPATests_savvy_v35.R
 APPDIR = /sw/ph/centos7/encore/scripts/saige/


### PR DESCRIPTION
Changes the R installation that encore uses from R with default BLAS/LAPACK to R with OpenBLAS. This resolves the intermittent segmentation fault (seg fault, segfault, core dump) issue.